### PR TITLE
Bump websockets' version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6.1, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6.1, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Python library makes it easy to run [Geocortex Reporting](https://www.geoco
 
 ## Requirements
 
-- Python 3.6 or later
+- Python 3.6.1 or later
 
 ## Installing the package
 

--- a/geocortex/reporting/client/reporting_service.py
+++ b/geocortex/reporting/client/reporting_service.py
@@ -1,7 +1,7 @@
 import json
 import time
 import requests
-import websockets
+from websockets.client import connect
 
 from .portal_utils import get_portal_item
 
@@ -122,7 +122,7 @@ async def _wait_for_job_result_ws(service_url: str, ticket: str) -> str:
     ws_service_url = service_url.replace("http", "ws")
     artifacts_service_url = f"{ws_service_url}/job/artifacts?ticket={ticket}"
 
-    async with websockets.connect(artifacts_service_url, ssl=True) as websocket:
+    async with connect(artifacts_service_url, ssl=True) as websocket:
         message = await websocket.recv()
         job_status = json.loads(message)
         artifact_url = _check_job_status(service_url, ticket, job_status)

--- a/geocortex/reporting/client/reporting_service.py
+++ b/geocortex/reporting/client/reporting_service.py
@@ -54,9 +54,7 @@ def _get_reporting_token_if_needed(
     return ""
 
 
-def _build_job_args(
-    template_arg: dict, args: dict, culture: str, dpi: int
-) -> dict:
+def _build_job_args(template_arg: dict, args: dict, culture: str, dpi: int) -> dict:
     job_args = {
         "template": template_arg,
         "parameters": [],
@@ -81,9 +79,7 @@ def _build_job_args(
     return job_args
 
 
-def _build_template_arg(
-    item_id: str, portal_url: str, result_file_name: str
-) -> dict:
+def _build_template_arg(item_id: str, portal_url: str, result_file_name: str) -> dict:
     template = {"itemId": item_id, "portalUrl": portal_url}
 
     if result_file_name:

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ URL = "https://github.com/geocortex/vertigis-reporting-client-py"
 EMAIL = "packages@geocortex.com"
 AUTHOR = "VertiGIS"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 
 # What packages are required for this module to be executed?
-REQUIRED = ["requests>=2.24.0,<3", "websockets>=8.1,<9"]
+REQUIRED = ["requests>=2.24.0,<3", "websockets>=9.1,<10"]
 
 # What packages are optional?
 DEV_EXTRAS = ["aiounittest>=1.4.0,<2", "black>=19.10b", "pylint>=2.5.3,<3", "responses>=0.10.16,<0.11"]

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,13 @@ DESCRIPTION = "A Python client for running Geocortex Reporting jobs."
 URL = "https://github.com/geocortex/vertigis-reporting-client-py"
 EMAIL = "packages@geocortex.com"
 AUTHOR = "VertiGIS"
-REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "1.1.1"
+REQUIRES_PYTHON = ">=3.6.1"
+VERSION = "2.0.0"
 
-# What packages are required for this module to be executed?
+# These packages are required for this module to be executed
 REQUIRED = ["requests>=2.24.0,<3", "websockets>=9.1,<10"]
 
-# What packages are optional?
+# These packages are optional
 DEV_EXTRAS = ["aiounittest>=1.4.0,<2", "black>=19.10b", "pylint>=2.5.3,<3", "responses>=0.10.16,<0.11"]
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Bump `websockets` package to handle [security issue](https://github.com/geocortex/vertigis-reporting-client-py/security/dependabot/setup.py/websockets/open).
Bump major version number as [websockets requires python 3.6.1](https://websockets.readthedocs.io/en/stable/intro.html) and this package originally said 3.6.